### PR TITLE
Using docker.com instead of .io. Updated to recommended keyserver.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,12 +2,12 @@
 
 - name: Adding APT key
   apt_key:
-    id: "A88D21E9"
-    url: "http://get.docker.io/gpg"
+    id: "36A1D7869245C8950F966E92D8576A8BA88D21E9"
+    keyserver: "hkp://p80.pool.sks-keyservers.net:80"
 
 - name: Adding APT repository
   apt_repository:
-    repo: 'deb http://get.docker.io/ubuntu docker main'
+    repo: 'deb https://get.docker.com/ubuntu docker main'
     update_cache: yes
 
 - name: Installing APT packages


### PR DESCRIPTION
Occasionally, key verification issues for installing `lxc-docker` appear when running the `install.yml` playbook. The BAGSIG error is similar to that described here: https://github.com/docker/docker/issues/12461.

The recommended is to change from docker.io to docker.com, and indeed, that is the recommended way of installing docker: https://get.docker.com/ubuntu/.

This PR:
1. Changes from `http://get.docker.io/ubuntu` to `https://get.docker.com/ubuntu` (note the change from http to https).
2. Changes from `http://get.docker.io/gpg` to the currently recommended docker keyserver: `hkp://p80.pool.sks-keyservers.net:80`.

I tested the this playbook using Vagrant on Ubuntu 14.04 64-bit without issue.
