### PR TITLE
Remove docker-py

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,8 +9,3 @@
 - name: 'Installing Ansible dependencies'
   easy_install:
     name: pip
-
-- name: 'Installing Ansible PIP dependencies'
-  pip:
-    name: docker-py
-    state: present


### PR DESCRIPTION
docker-py now breaks docker v2.2.0
https://github.com/docker/docker-py/issues/1395

resulting in errors during `docker-compose up`  :

    Dependency conflict: an older version of the 'docker-py' package is polluting the namespace. Run the following command to remedy the issue:
    pip uninstall docker docker-py; pip install docker

Might also set `state: absent` to uninstall docker-py, but don't want to break existing installs with older versions of docker.