### PR TITLE
Configure DEB & RPM docker-ce repository urls as variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - echo localhost > inventory
   - ln -s ansible-docker ../weareinteractive.docker
   - ansible-playbook --syntax-check -i inventory tests/main.yml
-  - ansible-playbook -i inventory tests/main.yml --connection=local --sudo -vvvv
+  - ansible-playbook -i inventory tests/main.yml --connection=local --become -vvvv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.12.O"></a>
+### 1.12.0 (2021-01-XX)
+
+
+#### Features
+
+*   configured docker ce epository url as variables to allow use of a local mirror or a private repo. 
+
 <a name="1.11.1"></a>
 ### 1.11.1 (2019-01-28)
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,12 @@ docker_options: []
 docker_images: []
 # list of containers (http://docs.ansible.com/docker_module.html)
 docker_containers: []
-
+# centos docker ce private repository url
+centos_docker_ce_private_repo: 'https://download.docker.com/linux/centos/7/$basearch/stable'
+centos_docker_ce_private_repo_gpg: 'https://download.docker.com/linux/centos/gpg'
+# debian docker ce private repository url
+debian_docker_ce_private_repo: 'https://download.docker.com/linux/{{ ansible_distribution | lower }}'
+debian_docker_ce_private_repo_gpg: 'https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg'
 ```
 
 ## Handlers

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,3 +41,9 @@ docker_options: []
 docker_images: []
 # list of containers (http://docs.ansible.com/docker_module.html)
 docker_containers: []
+# centos docker ce private repository url
+centos_docker_ce_private_repo: 'https://download.docker.com/linux/centos/7/$basearch/stable'
+centos_docker_ce_private_repo_gpg: 'https://download.docker.com/linux/centos/gpg'
+# debian docker ce private repository url
+debian_docker_ce_private_repo: 'https://download.docker.com/linux/{{ ansible_distribution | lower }}'
+debian_docker_ce_private_repo_gpg: 'https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg'

--- a/tasks/install/centos.yml
+++ b/tasks/install/centos.yml
@@ -16,8 +16,8 @@
   yum_repository:
     name: docker-ce-stable
     description: Docker CE Stable - $basearch
-    baseurl: '{{ centos_docker_ce_private_repo }}'
+    baseurl: "{{ centos_docker_ce_private_repo }}"
     enabled: yes
     gpgcheck: yes
-    gpgkey: '{{ centos_docker_ce_private_repo_gpg }}'
+    gpgkey: "{{ centos_docker_ce_private_repo_gpg }}"
 

--- a/tasks/install/centos.yml
+++ b/tasks/install/centos.yml
@@ -16,8 +16,8 @@
   yum_repository:
     name: docker-ce-stable
     description: Docker CE Stable - $basearch
-    baseurl: https://download.docker.com/linux/centos/7/$basearch/stable
+    baseurl: '{{ centos_docker_ce_private_repo }}'
     enabled: yes
     gpgcheck: yes
-    gpgkey: https://download.docker.com/linux/centos/gpg
+    gpgkey: '{{ centos_docker_ce_private_repo_gpg }}'
 

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -20,7 +20,7 @@
 - name: Adding APT key
   apt_key:
     id: 0EBFCD88
-    url: {{ debian_docker_ce_private_repo_gpg }}
+    url: "{{ debian_docker_ce_private_repo_gpg }}"
 
 - name: Adding APT repository
   apt_repository:

--- a/tasks/install/ubuntu.yml
+++ b/tasks/install/ubuntu.yml
@@ -20,9 +20,9 @@
 - name: Adding APT key
   apt_key:
     id: 0EBFCD88
-    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+    url: {{ debian_docker_ce_private_repo_gpg }}
 
 - name: Adding APT repository
   apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+    repo: "deb [arch=amd64] {{ debian_docker_ce_private_repo }} {{ ansible_distribution_release }} stable"
     update_cache: yes


### PR DESCRIPTION
 - Configured DEB & RPM docker ce repository urls as variables to allow use of a local mirror of the official repository.
 - Updated readme with ànsible-role docgen` command.
 - Proposed changelog for v1.12.0
 - Updated travis-ci config with **--become parameter** as a replacement for deprecated **--sudo** parameter